### PR TITLE
Prevent possible stuck case in Dire Maul Tribute Run

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/instance_dire_maul.cpp
+++ b/src/game/AI/ScriptDevAI/scripts/kalimdor/dire_maul/instance_dire_maul.cpp
@@ -305,6 +305,7 @@ void instance_dire_maul::SetData(uint32 uiType, uint32 uiData)
                     // start WP movement for Mizzle; event handled by movement and gossip dbscripts
                     if (Creature* pMizzle = pOgre->SummonCreature(NPC_MIZZLE_THE_CRAFTY, afMizzleSpawnLoc[0], afMizzleSpawnLoc[1], afMizzleSpawnLoc[2], afMizzleSpawnLoc[3], TEMPSPAWN_DEAD_DESPAWN, 0, true))
                     {
+                        pMizzle->RemoveFlag(UNIT_NPC_FLAGS, UNIT_NPC_FLAG_GOSSIP);
                         pMizzle->SetWalk(false);
                         pMizzle->GetMotionMaster()->MoveWaypoint();
                     }


### PR DESCRIPTION
* Prevent players from displaying too early Mizzle the Crafty's gossip menu, stucking him before he reaches the intended waypoint.
NpcFlags are further handled by DB scripts.